### PR TITLE
verify: continue after bottle verification failure

### DIFF
--- a/cmd/verify.rb
+++ b/cmd/verify.rb
@@ -71,7 +71,7 @@ module Homebrew
                 oh1 "#{bottle.filename} has a valid attestation"
                 json_results.push(attestation)
               rescue Homebrew::Attestation::InvalidAttestationError => e
-                odie <<~ERR
+                ofail <<~ERR
                   Failed to verify #{bottle.filename} with tag #{bottle_tag} due to error:
 
                   #{e}


### PR DESCRIPTION
`brew verify` uses `#odie` to print an error when bottle verification fails but this causes the process to exit. If the user runs `verify` for more than one OS/arch, a failure can prevent the command from checking all of the bottles.

This replaces the `#odie` call with `#ofail`, which will print an error in the same fashion and set `Homebrew.failed = true` instead of exiting early with a `1` status code. This allows the command to continue checking subsequent bottles after a failure.